### PR TITLE
Introduce --remote-cache flag for `dev build`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Dev is the general-purpose dev tool for folks working cockroachdb/cockroach.
+Dev is a general-purpose dev tool for folks working on [cockroachdb/cockroach](https://github.com/cockroachdb/cockroach/).
 
     $ go get -u github.com/cockroachdb/dev
     $ go install github.com/cockroachdb/dev

--- a/main.go
+++ b/main.go
@@ -49,7 +49,10 @@ lets engineers do a few things:
 	SilenceErrors: true,
 }
 
-var bazel = "bazel"
+var (
+	bazel           = "bazel"
+	remoteCacheFlag = "remote-cache"
+)
 
 func init() {
 	log.SetFlags(0)
@@ -84,7 +87,7 @@ func runDev() error {
 
 func main() {
 	if err := runDev(); err != nil {
-		log.Printf("%v", err)
+		log.Printf("error: %v", err)
 		os.Exit(1)
 	}
 }

--- a/test.go
+++ b/test.go
@@ -77,6 +77,9 @@ func init() {
 	testCmd.Flags().String(filesFlag, "", "run logic tests for files matching this regex")
 	testCmd.Flags().String(subtestsFlag, "", "run logic test subtests matching this regex")
 	testCmd.Flags().String(configFlag, "", "run logic tests under the specified config")
+
+	// Shared flags.
+	testCmd.Flags().String(remoteCacheFlag, "", "remote caching endpoint to use")
 }
 
 func runTest(ctx context.Context, cmd *cobra.Command, pkgs []string) error {
@@ -99,6 +102,7 @@ func runUnitTest(ctx context.Context, cmd *cobra.Command, pkgs []string) error {
 	ignoreCache := mustGetFlagBool(cmd, ignoreCacheFlag)
 	verbose := mustGetFlagBool(cmd, vFlag)
 	showLogs := mustGetFlagBool(cmd, showLogsFlag)
+	cAddr := mustGetFlagString(cmd, remoteCacheFlag)
 
 	if showLogs {
 		return errors.New("-show-logs unimplemented")
@@ -113,6 +117,11 @@ func runUnitTest(ctx context.Context, cmd *cobra.Command, pkgs []string) error {
 		args = append(args, "--features", "race")
 	}
 	args = append(args, "--color=yes")
+	if cAddr != "" {
+		args = append(args, "--remote_local_fallback")
+		args = append(args, fmt.Sprintf("--remote_cache=grpc://%s", cAddr))
+		args = append(args, fmt.Sprintf("--experimental_remote_downloader=grpc://%s", cAddr))
+	}
 
 	for _, pkg := range pkgs {
 		if strings.HasSuffix(pkg, "...") {


### PR DESCRIPTION
And also avoid polluting the workspace with convenience symlinks.