### PR TITLE
Implement ... expansion for `dev test`

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@
 package main
 
 import (
+	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -50,21 +51,42 @@ lets engineers do a few things:
 }
 
 var (
-	bazel           = "bazel"
-	remoteCacheFlag = "remote-cache"
+	remoteCacheAddr string
+	debugLogger     = log.New(ioutil.Discard, "DEBUG: ", 0)
 )
 
 func init() {
 	log.SetFlags(0)
 	log.SetPrefix("")
 
-	devCmd.AddCommand(
+	cmds := []*cobra.Command{
 		benchCmd,
 		buildCmd,
 		generateCmd,
 		lintCmd,
 		testCmd,
-	)
+	}
+
+	// Add all the shared flags.
+	var debugVar bool
+	for _, cmd := range cmds {
+		cmd.Flags().BoolVar(&debugVar, "debug", false, "enable debug logging for dev itself")
+		// This points to the grpc endpoint of a running `buchr/bazel-remote`
+		// instance. We're tying ourselves to the one implementation, but that
+		// seems fine for now. It seems mature, and has (very experimental)
+		// support for the  Remote Asset API, which helps speed things up when
+		// the cache sits across the network boundary.
+		cmd.Flags().StringVar(&remoteCacheAddr, "remote-cache", "", "remote caching grpc endpoint to use")
+	}
+	for _, cmd := range cmds {
+		cmd.PreRun = func(cmd *cobra.Command, args []string) {
+			if debugVar {
+				debugLogger.SetOutput(os.Stderr)
+			}
+		}
+	}
+
+	devCmd.AddCommand(cmds...)
 
 	// Hide the `help` sub-command.
 	devCmd.SetHelpCommand(&cobra.Command{
@@ -74,7 +96,7 @@ func init() {
 }
 
 func runDev() error {
-	_, err := exec.LookPath(bazel)
+	_, err := exec.LookPath("bazel")
 	if err != nil {
 		return errors.New("bazel not found in $PATH")
 	}
@@ -87,7 +109,7 @@ func runDev() error {
 
 func main() {
 	if err := runDev(); err != nil {
-		log.Printf("error: %v", err)
+		log.Printf("ERROR: %v", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
And isolate dev-internal debug logging (introducing a mechanism to
toggle it), refactor out shared flags, and add some extra validation
code for --remote-cache.

---

First commit is from https://github.com/cockroachdb/dev/pull/3, ignore here.