### PR TITLE
Log test errors inline when non-verbose

### DIFF
--- a/test.go
+++ b/test.go
@@ -180,6 +180,8 @@ func runUnitTest(ctx context.Context, cmd *cobra.Command, pkgs []string) error {
 	}
 	if verbose {
 		args = append(args, "--test_output", "all", "--test_arg", "-test.v")
+	} else {
+		args = append(args, "--test_output", "errors")
 	}
 
 	return execute(ctx, "bazel", args...)


### PR DESCRIPTION
The alternative is a bit more cumbersome to work with:

    INFO: Build completed, 1 test FAILED, 2 total actions
    //pkg/util/tracing:tracing_test
      /private/var/tmp/_bazel_irfansharif/<...>/tracing/tracing_test/test.log

    INFO: Build completed, 1 test FAILED, 2 total actions
    ERROR: exit status 3