### PR TITLE
Introduce --cpus to cap the number of cpus in use

### DIFF
--- a/build.go
+++ b/build.go
@@ -12,6 +12,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path"
@@ -69,6 +70,9 @@ func runBuild(cmd *cobra.Command, targets []string) error {
 	// ourself.
 	args = append(args, "--experimental_convenience_symlinks=ignore")
 	args = append(args, mustGetRemoteCacheArgs(remoteCacheAddr)...)
+	if numCPUs != 0 {
+		args = append(args, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))
+	}
 
 	for _, target := range targets {
 		buildTarget, ok := buildTargetMapping[target]

--- a/main.go
+++ b/main.go
@@ -52,6 +52,7 @@ lets engineers do a few things:
 
 var (
 	remoteCacheAddr string
+	numCPUs         int
 	debugLogger     = log.New(ioutil.Discard, "DEBUG: ", 0)
 )
 
@@ -70,7 +71,8 @@ func init() {
 	// Add all the shared flags.
 	var debugVar bool
 	for _, cmd := range cmds {
-		cmd.Flags().BoolVar(&debugVar, "debug", false, "enable debug logging for dev itself")
+		cmd.Flags().BoolVar(&debugVar, "debug", false, "enable debug logging for dev")
+		cmd.Flags().IntVar(&numCPUs, "cpus", 0, "cap the number of cpu cores used")
 		// This points to the grpc endpoint of a running `buchr/bazel-remote`
 		// instance. We're tying ourselves to the one implementation, but that
 		// seems fine for now. It seems mature, and has (very experimental)

--- a/test.go
+++ b/test.go
@@ -113,6 +113,9 @@ func runUnitTest(ctx context.Context, cmd *cobra.Command, pkgs []string) error {
 	args = append(args, "--color=yes")
 	args = append(args, "--experimental_convenience_symlinks=ignore") // don't generate any convenience symlinks
 	args = append(args, mustGetRemoteCacheArgs(remoteCacheAddr)...)
+	if numCPUs != 0 {
+		args = append(args, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))
+	}
 	if race {
 		args = append(args, "--features", "race")
 	}


### PR DESCRIPTION
We have the equivalent of this in our Makefile and it comes in handy.
Without it any build/test/stresstest attempt completely hogs all
available cores and renders the working machine inoperable.