### PR TITLE
Add warning about the current pre-alpha status of `dev`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+WARNING: `dev` isn't feature-complete, and the migration to Bazel at Cockroach
+is still in-progress. Proceed at your own risk :)
+
 Dev is a general-purpose dev tool for folks working on [cockroachdb/cockroach](https://github.com/cockroachdb/cockroach/).
 
     $ go get -u github.com/cockroachdb/dev


### PR DESCRIPTION
In the absence of something like this, people might start using `dev`
in places where it's not appropriate.