### PR TITLE
Disable ccache by setting CCACHE_DISABLE=1

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,6 +20,10 @@ func main() {
 	log.SetFlags(0)
 	log.SetPrefix("")
 
+	// Disable ccache by setting CCACHE_DISABLE. We don't want it to write to files outside the bazel sandbox.
+	if err := os.Setenv("CCACHE_DISABLE", "1"); err != nil {
+		log.Fatal("Failed to set `CCACHE_DISABLE`")
+	}
 	if _, err := exec.LookPath("bazel"); err != nil {
 		log.Printf("ERROR: bazel not found in $PATH")
 		os.Exit(1)


### PR DESCRIPTION
Fixes #11

To prevent `ccache` to write to its cache which lives outside the Bazel
sandbox, we can set `CCACHE_DISABLE` to `1`. According to its manual
page, `ccache` will directly call to the original compiler.